### PR TITLE
fix: remove Node.js requirement for Claude Code install (#1)

### DIFF
--- a/CURRICULUM_CLAUDE_MAC.md
+++ b/CURRICULUM_CLAUDE_MAC.md
@@ -134,27 +134,22 @@ git --version  # git version 2.x.x が表示されれば成功
 
 ---
 
-## Step 4: Node.js のインストール（Claude Code CLI に必要）
+## Step 4: Claude Code CLI のインストール
+
+Node.js は不要です。公式のネイティブインストーラーを使用します。
 
 ```bash
-node --version  # v18以上であればOK
-```
-
-インストールされていない場合: `https://nodejs.org/` から **LTS版** をダウンロードしてインストール
-
----
-
-## Step 5: Claude Code CLI のインストール
-
-```bash
-npm install -g @anthropic-ai/claude-code
+# macOS ネイティブインストーラー（Node.js 不要）
+curl -fsSL https://claude.ai/install.sh | sh
 claude --version   # バージョンが表示されれば成功
 claude login       # ブラウザが開く → Anthropicアカウントでログイン
 ```
 
+> **補足:** 最新のインストール手順は公式ドキュメント（https://docs.anthropic.com/ja/docs/claude-code/setup）を確認してください。
+
 ---
 
-## Step 6: VS Code の Claude Code 拡張機能をインストール
+## Step 5: VS Code の Claude Code 拡張機能をインストール
 
 1. VS Codeを開く
 2. 左サイドバーの拡張機能アイコン（四角）をクリック


### PR DESCRIPTION
Claude Code がネイティブインストール可能になったため、Node.js インストール手順（旧 Step 4）を削除し、ネイティブインストーラーを使う手順に更新。

## 変更内容
- Step 4（Node.js のインストール）を削除
- 旧 Step 5 → Step 4 に番号変更（ネイティブインストーラーを使用）
- 旧 Step 6 → Step 5 に番号変更

## 対象ファイル
- `CURRICULUM_CLAUDE_MAC.md` のみ（他ファイルは後続 Issue で対応）

Closes #1