### PR TITLE
fix: create GitHub repository as private (#3)

### DIFF
--- a/CURRICULUM_CLAUDE_MAC.md
+++ b/CURRICULUM_CLAUDE_MAC.md
@@ -273,7 +273,7 @@ uvを使ってtaskrプロジェクトのPython環境をセットアップして�
 ```
 以下を順番に実施してください:
 
-1. gh repo create learn_claude --public でGitHubリポジトリを作成
+1. gh repo create learn_claude --private でGitHubリポジトリを作成
 2. git init（カレントディレクトリで実行）
 3. git remote add origin [リポジトリURL]
 4. ~/.zshrc に以下を追加:


### PR DESCRIPTION
学習用リポジトリは private で作成するよう変更。

## 変更内容
- P0-5: `gh repo create learn_claude --public` → `--private` に変更

Closes #3