### PR TITLE
fix: add -u flag to initial push command (#5)

### DIFF
--- a/CURRICULUM_CLAUDE_MAC.md
+++ b/CURRICULUM_CLAUDE_MAC.md
@@ -345,7 +345,7 @@ Phase 0はmainブランチへ直接コミット（初期セットアップのた
 ```bash
 git add CLAUDE.md .gitignore .claudeignore taskr/pyproject.toml
 git commit -m "feat(phase0): initial project setup with Python 3.12 via uv"
-git push origin main
+git push -u origin main
 ```
 
 セッション管理:


### PR DESCRIPTION
Phase 0 の初回プッシュに `-u` オプションを追加。

## 変更内容
- `git push origin main` → `git push -u origin main`
- `-u` を付けることで upstream が設定され、以降 `git push` だけで実行できるようになる

Closes #5