### PR TITLE
fix: apply issue #1-#5 fixes to all remaining curricula (#7)

### DIFF
--- a/CURRICULUM_CLAUDE_WINDOWS.md
+++ b/CURRICULUM_CLAUDE_WINDOWS.md
@@ -152,35 +152,22 @@ git config --global user.email "あなたのメール"
 
 ---
 
-## Step 5: Node.js のインストール
+## Step 5: Claude Code CLI のインストール
+
+Node.js は不要です。公式のネイティブインストーラーを使用します。
 
 ```powershell
-node --version  # v18以上であればOK
-```
-
-インストールされていない場合:
-1. `https://nodejs.org/` から **LTS版** の Windows Installer (.msi) をダウンロード
-2. インストール（デフォルト設定でOK）
-3. PowerShell を **再起動** して確認
-
-```powershell
-node --version   # v20.x.x などが表示されれば成功
-npm --version
-```
-
----
-
-## Step 6: Claude Code CLI のインストール
-
-```powershell
-npm install -g @anthropic-ai/claude-code
+# PowerShell でネイティブインストーラーを実行
+iwr https://claude.ai/install.ps1 | iex
 claude --version   # バージョンが表示されれば成功
 claude login       # ブラウザが開く → Anthropicアカウントでログイン
 ```
 
+> **補足:** 最新のインストール手順は公式ドキュメント（https://docs.anthropic.com/ja/docs/claude-code/setup）を確認してください。
+
 ---
 
-## Step 7: VS Code の Claude Code 拡張機能をインストール
+## Step 6: VS Code の Claude Code 拡張機能をインストール
 
 1. VS Codeを開く
 2. 左サイドバーの拡張機能アイコン（四角）をクリック
@@ -197,7 +184,6 @@ claude login       # ブラウザが開く → Anthropicアカウントでログ
 
 - [ ] `code --version` が動作する
 - [ ] `git --version` が動作する
-- [ ] `node --version` が v18以上
 - [ ] `claude --version` が動作する
 - [ ] `claude` 起動後にログイン済みと表示される
 - [ ] VS Code に Claude Code 拡張がインストール済み
@@ -215,7 +201,16 @@ claude login       # ブラウザが開く → Anthropicアカウントでログ
 - uv（Python管理ツール）による仮想環境構築
 - GitHubリポジトリの初期化
 
-**セッション開始:** Windows Terminal（PowerShell 7）で `claude` を起動
+**セッション開始前に（手動）:** 学習作業を行うディレクトリを自分で決めて作成し、そこへ移動してから `claude` を起動する。
+
+```powershell
+# 例: 好きな場所に作業ディレクトリを作成
+mkdir $env:USERPROFILE\your\working\directory
+cd $env:USERPROFILE\your\working\directory
+claude   # このディレクトリで起動することが重要
+```
+
+> 以降の手順はすべて「claude を起動したディレクトリ」を基準に動作します。
 
 > **Agent活用の原則（このフェーズから意識する）**
 > メインセッションは「指示を出す」ことに専念し、実行はClaude Codeに任せる。
@@ -281,8 +276,8 @@ WindowsのPowerShell環境で実行してください。
 
 順番に実行してください（各ステップ前に確認を取ること）:
 1. uv python install 3.12
-2. New-Item -ItemType Directory -Path "$env:USERPROFILE\study\workspace\learn_claude\taskr" -Force
-3. Set-Location "$env:USERPROFILE\study\workspace\learn_claude\taskr"
+2. mkdir taskr
+3. cd taskr
 4. uv init --python 3.12
 5. uv venv
 6. uv add click
@@ -298,8 +293,8 @@ WindowsのPowerShell環境で実行してください。
 ```
 以下を順番に実施してください（PowerShell環境で）:
 
-1. gh repo create learn_claude --public でGitHubリポジトリを作成
-2. "$env:USERPROFILE\study\workspace\learn_claude\" で git init
+1. gh repo create learn_claude --private でGitHubリポジトリを作成
+2. git init（カレントディレクトリで実行）
 3. git remote add origin [リポジトリURL]
 4. PowerShellプロファイルに環境変数を追加:
    - プロファイルファイルのパスを確認: echo $PROFILE
@@ -375,7 +370,7 @@ Phase 0はmainブランチへ直接コミット（初期セットアップのた
 ```powershell
 git add CLAUDE.md .gitignore .claudeignore taskr/pyproject.toml
 git commit -m "feat(phase0): initial project setup with Python 3.12 via uv"
-git push origin main
+git push -u origin main
 ```
 
 セッション管理:

--- a/CURRICULUM_CODEX_MAC.md
+++ b/CURRICULUM_CODEX_MAC.md
@@ -214,7 +214,16 @@ Codex CLIはターミナルツールですが、VS Codeと組み合わせると�
 - uv（Python管理ツール）による仮想環境構築
 - GitHubリポジトリの初期化
 
-**セッション開始:** ターミナルで `codex` を起動
+**セッション開始前に（手動）:** 学習作業を行うディレクトリを自分で決めて作成し、そこへ移動してから `codex` を起動する。
+
+```bash
+# 例: 好きな場所に作業ディレクトリを作成
+mkdir -p ~/your/working/directory
+cd ~/your/working/directory
+codex   # このディレクトリで起動することが重要
+```
+
+> 以降の手順はすべて「codex を起動したディレクトリ」を基準に動作します。
 
 > **Agent活用の原則（このフェーズから意識する）**
 > メインセッションは「指示を出す」ことに専念し、実行はCodex CLIに任せる。
@@ -278,8 +287,8 @@ uvを使ってtaskrプロジェクトのPython環境をセットアップして�
 
 順番に実行してください（各ステップ前に確認を取ること）:
 1. uv python install 3.12
-2. mkdir -p ~/study/workspace/learn_claude/taskr
-3. cd ~/study/workspace/learn_claude/taskr
+2. mkdir taskr
+3. cd taskr
 4. uv init --python 3.12
 5. uv venv
 6. uv add click
@@ -295,8 +304,8 @@ uvを使ってtaskrプロジェクトのPython環境をセットアップして�
 ```
 以下を順番に実施してください:
 
-1. gh repo create learn_claude --public でGitHubリポジトリを作成
-2. ~/study/workspace/learn_claude/ で git init
+1. gh repo create learn_claude --private でGitHubリポジトリを作成
+2. git init（カレントディレクトリで実行）
 3. git remote add origin [リポジトリURL]
 4. ~/.codex/config.toml を以下の内容で作成:
 
@@ -373,7 +382,7 @@ Phase 0はmainブランチへ直接コミット（初期セットアップのた
 ```bash
 git add AGENTS.md .gitignore taskr/pyproject.toml
 git commit -m "feat(phase0): initial project setup with Python 3.12 via uv"
-git push origin main
+git push -u origin main
 ```
 
 セッション管理:
@@ -799,7 +808,7 @@ rm -rf を含むコマンドが提案された場合は必ず警告を表示し�
 ## タスク P3-4: .codexignore の整備
 
 ```
-~/study/workspace/learn_claude/.codexignore を作成してください。
+.codexignore を作成してください（作業ディレクトリ直下に配置）。
 Codex CLIがコンテキストに含めるべきでないファイルを除外します。
 
 除外すべきパス:
@@ -1523,7 +1532,8 @@ codex exec --full-auto "以下のリリース前チェックを自動実行し�
 
 ```bash
 # リリース前自動チェックスクリプトを作成してください
-cat > ~/study/workspace/learn_claude/scripts/pre-release-check.sh << 'EOF'
+mkdir -p scripts
+cat > scripts/pre-release-check.sh << 'EOF'
 #!/bin/bash
 set -e
 
@@ -1537,7 +1547,7 @@ git diffでmainからの変更を分析し、リリースに問題がないか�
 
 echo "=== チェック完了 ==="
 EOF
-chmod +x ~/study/workspace/learn_claude/scripts/pre-release-check.sh
+chmod +x scripts/pre-release-check.sh
 ```
 
 ```
@@ -1678,7 +1688,7 @@ uv add でライブラリを追加してから実装してください。
 
 ```bash
 # Phase 8で作成したスクリプトを実行
-bash ~/study/workspace/learn_claude/scripts/pre-release-check.sh
+bash scripts/pre-release-check.sh
 ```
 
 ```bash

--- a/CURRICULUM_CODEX_WINDOWS.md
+++ b/CURRICULUM_CODEX_WINDOWS.md
@@ -255,7 +255,16 @@ gh auth login   # ブラウザでGitHub認証
 - AGENTS.mdの作成（Codex CLIのコンテキスト引き継ぎファイル）
 - GitHubリポジトリの初期化
 
-**セッション開始:** WSL2（Ubuntu）ターミナルで `codex` を起動
+**セッション開始前に（手動）:** 学習作業を行うディレクトリを自分で決めて作成し、そこへ移動してから `codex` を起動する。
+
+```bash
+# 例: 好きな場所に作業ディレクトリを作成（WSL2ターミナルで実行）
+mkdir -p ~/your/working/directory
+cd ~/your/working/directory
+codex   # このディレクトリで起動することが重要
+```
+
+> 以降の手順はすべて「codex を起動したディレクトリ」を基準に動作します。
 
 > **Agent活用の原則（このフェーズから意識する）**
 > メインセッションは「指示を出す」ことに専念し、実行はCodex CLIに任せる。
@@ -283,16 +292,11 @@ gh auth login   # ブラウザでGitHub認証
 Codex CLIを起動する前に、WSL2内で以下を確認・実行する:
 
 ```bash
-# WSL2（Ubuntu）ターミナルで実行
-# 作業ディレクトリの作成
-mkdir -p ~/study/workspace/learn_claude
-cd ~/study/workspace/learn_claude
-
 # WSL2からWindowsのファイルシステムにアクセスする場合のパス確認
 # （必要に応じて）Windowsのファイルは /mnt/c/Users/<username>/ からアクセス可能
 ls /mnt/c/Users/
 
-# Codex CLIを起動
+# Codex CLIを起動（作業ディレクトリで起動済みであること）
 codex
 ```
 
@@ -339,8 +343,8 @@ uvを使ってtaskrプロジェクトのPython環境をWSL2（Ubuntu）上でセ
 
 順番に実行してください（各ステップ前に確認を取ること）:
 1. uv python install 3.12
-2. mkdir -p ~/study/workspace/learn_claude/taskr
-3. cd ~/study/workspace/learn_claude/taskr
+2. mkdir taskr
+3. cd taskr
 4. uv init --python 3.12
 5. uv venv
 6. uv add click
@@ -356,8 +360,8 @@ uvを使ってtaskrプロジェクトのPython環境をWSL2（Ubuntu）上でセ
 ```
 以下を順番に実施してください（WSL2のbash環境で）:
 
-1. gh repo create learn_claude --public でGitHubリポジトリを作成
-2. ~/study/workspace/learn_claude/ で git init
+1. gh repo create learn_claude --private でGitHubリポジトリを作成
+2. git init（カレントディレクトリで実行）
 3. git remote add origin [リポジトリURL]
 4. ~/.codex/config.toml を以下の内容で作成:
 
@@ -444,7 +448,7 @@ Phase 0はmainブランチへ直接コミット（初期セットアップのた
 ```bash
 git add AGENTS.md .gitignore .codexignore taskr/pyproject.toml
 git commit -m "feat(phase0): initial project setup with Python 3.12 via uv on WSL2"
-git push origin main
+git push -u origin main
 ```
 
 セッション管理:
@@ -568,7 +572,7 @@ Suggest Modeで確認した設計内容をAGENTS.mdに記録してください�
 ## タスク P1-4: /mention コマンドの活用
 
 ```
-/mention ~/study/workspace/learn_claude/taskr/pyproject.toml
+/mention taskr/pyproject.toml
 ```
 
 → ファイルをコンテキストに追加してから、内容について質問・分析する体験をする。
@@ -852,7 +856,7 @@ notify設定2: notify-send が使える場合はデスクトップ通知も追�
 
 1. デフォルトモデルを o4-mini に設定（既に設定済みか確認）
 2. 承認モードを suggest に設定（既に設定済みか確認）
-3. 作業ディレクトリのデフォルトを ~/study/workspace/learn_claude/ に設定
+3. 作業ディレクトリのデフォルトを（codex を起動したディレクトリ）に設定
 4. 設定の全オプションと意味を説明してください
 
 設定後、codex を再起動して設定が反映されているか /status で確認してください。


### PR DESCRIPTION
Issue #1〜#5 の修正を Mac Claude 以外の3ファイルに適用。

## 変更ファイル
- `CURRICULUM_CLAUDE_WINDOWS.md`
- `CURRICULUM_CODEX_MAC.md`
- `CURRICULUM_CODEX_WINDOWS.md`

## 適用した修正

| Issue | 内容 | Claude Windows | Codex Mac | Codex Windows |
|-------|------|:-:|:-:|:-:|
| #1 Node.js 不要 | native installer に変更 | ✅ | ➖ (Codex は npm 必須) | ➖ (Codex は npm 必須) |
| #2 作業ディレクトリ可変 | 起動前に自分で作成 + mkdir taskr / git init をカレントに | ✅ | ✅ | ✅ |
| #3 リポジトリ private | --public → --private | ✅ | ✅ | ✅ |
| #5 git push -u | -u フラグ追加 | ✅ | ✅ | ✅ |

## 補足
- Codex CLI は現在も Node.js/npm 必須のため Issue #1 は非適用
- Codex Mac の絶対パス（P3-4, P8-5, P9-4）も相対パスに修正
- Codex Windows の /mention パス・P3-2 設定パスも相対パスに修正

Closes #7