### PR TITLE
fix: クリーンマシン環境で動かない設定漏れを全カリキュラムで修正 (#16)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,7 @@ Claude Code および OpenAI Codex CLI を学ぶためのカリキュラム管�
 - `/rename` `/tag` の説明: Phase 1 タスクP1-5に追加済み
 - `Skills/カスタムコマンド`の説明: Phase 2に3種の区別（自動起動Skills・カスタムコマンド・組み込みコマンド）を追記済み
 - `/revise-claude-md` プラグイン: Phase 0 P0-5のsettings.json設定に有効化手順を追記済み
+- クリーンマシン対応: 全4カリキュラムのPhase 0〜3の設定漏れ14件を修正済み（#16）
 
 ## カリキュラム改善時のワークフロー
 
@@ -56,7 +57,8 @@ Claude Code および OpenAI Codex CLI を学ぶためのカリキュラム管�
 | 2026-02-27 | CLAUDE.md 作成（コンテキスト保全のため） |
 | 2026-02-28 | CURRICULUM.md → CURRICULUM_CLAUDE_MAC.md、CURRICULUM_WINDOWS.md → CURRICULUM_CLAUDE_WINDOWS.md にリネーム |
 | 2026-02-28 | CURRICULUM_CODEX_MAC.md・CURRICULUM_CODEX_WINDOWS.md 新規作成（Codex CLI版） |
-| 2026-03-02 | Phase 0 P0-5にclaude-md-managementプラグイン有効化手順を追加；Phase 2「Skillsとは」説明を修正（自動起動Skills・カスタムコマンド・組み込みコマンドの区別を明記）(#1) |
+| 2026-03-02 | Phase 0 P0-5にclaude-md-managementプラグイン有効化手順を追加；Phase 2「Skillsとは」説明を修正（自動起動Skills・カスタムコマンド・組み込みコマンドの区別を明記）(#15) |
+| 2026-03-02 | 全4カリキュラムのクリーンマシン対応修正：プラグイン有効化・source漏れ・hooks dir・pytest-cov・git push -u・ExecutionPolicy・MCP再起動・gh auth確認など計14件修正 (#16) |
 
 ## 次に改善したいこと（アイデアメモ）
 

--- a/CURRICULUM_CLAUDE_MAC.md
+++ b/CURRICULUM_CLAUDE_MAC.md
@@ -247,6 +247,7 @@ brew install gh
 
 # ない場合はClaude Codeが適切な方法を案内してくれる
 gh auth login   # ブラウザでGitHub認証
+gh auth status  # 認証済みと表示されることを確認
 ```
 
 ## タスク P0-4: Python + 仮想環境のセットアップ
@@ -278,13 +279,20 @@ uvを使ってtaskrプロジェクトのPython環境をセットアップして�
 3. git remote add origin [リポジトリURL]
 4. ~/.zshrc に以下を追加:
    export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1
-5. ~/.claude/settings.json を以下の内容で作成:
+   追加後は以下を実行して反映させてください:
+   source ~/.zshrc
+   echo $CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS  # 1 が表示されればOK
+5. ~/.claude/ ディレクトリを作成（存在しない場合）:
+   mkdir -p ~/.claude
+   ~/.claude/settings.json を以下の内容で作成:
    {
      "enabledPlugins": {
-       "claude-md-management@claude-plugins-official": true
+       "claude-md-management@claude-plugins-official": true,
+       "commit-commands@claude-plugins-official": true,
+       "feature-dev@claude-plugins-official": true
      }
    }
-   （`/revise-claude-md` コマンドを使えるようにするため）
+   （`/revise-claude-md`, `/commit`, `/commit-push-pr`, `/feature-dev` コマンドを使えるようにするため）
 6. CLAUDE.md を以下の内容で作成:
 
 ---
@@ -681,6 +689,11 @@ git checkout main && git pull origin main
 **フェーズ開始時にブランチを作成（手動）:**
 ```bash
 git checkout -b feature/phase3-hooks-skill
+```
+
+フックスクリプト用ディレクトリを作成:
+```bash
+mkdir -p ~/.claude/hooks
 ```
 
 ---

--- a/CURRICULUM_CLAUDE_WINDOWS.md
+++ b/CURRICULUM_CLAUDE_WINDOWS.md
@@ -252,8 +252,9 @@ Claude Codeが以下を提案するので承認するだけ:
 
 ```powershell
 powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
-# PowerShellを再起動後
-uv --version   # 確認
+# PowerShellを再起動してPATHを反映させてください
+# 再起動後に確認:
+uv --version      # バージョンが表示されればOK
 ```
 
 > **注意:** ExecutionPolicy の変更を求められた場合は `Set-ExecutionPolicy RemoteSigned -Scope CurrentUser` を実行してから再試行。
@@ -266,6 +267,7 @@ winget install GitHub.cli
 
 # winget がない場合は https://cli.github.com/ からインストーラをDL
 gh auth login   # ブラウザでGitHub認証
+gh auth status  # 認証済みと表示されることを確認
 ```
 
 ## タスク P0-4: Python + 仮想環境のセットアップ
@@ -300,8 +302,18 @@ WindowsのPowerShell環境で実行してください。
    - プロファイルファイルのパスを確認: echo $PROFILE
    - 以下を追記: $env:CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1"
    - プロファイルを再読み込み: . $PROFILE
-5. "$env:USERPROFILE\.claude\settings.json" に空のJSON {} を作成
-6. CLAUDE.md を以下の内容で作成:
+   - 確認: echo $env:CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS  # 1 が表示されればOK
+5. ~/.claude/ フォルダを作成（存在しない場合）:
+   mkdir -Force "$env:USERPROFILE\.claude"
+6. "$env:USERPROFILE\.claude\settings.json" に以下のJSONを作成:
+   {
+     "enabledPlugins": {
+       "claude-md-management@claude-plugins-official": true,
+       "commit-commands@claude-plugins-official": true,
+       "feature-dev@claude-plugins-official": true
+     }
+   }
+7. CLAUDE.md を以下の内容で作成:
 
 ---
 # taskr プロジェクト
@@ -686,6 +698,11 @@ git checkout main; git pull origin main
 **フェーズ開始時にブランチを作成（手動）:**
 ```powershell
 git checkout -b feature/phase3-hooks-skill
+```
+
+フックスクリプト用ディレクトリを作成:
+```powershell
+mkdir -Force "$env:USERPROFILE\.claude\hooks"
 ```
 
 ---

--- a/CURRICULUM_CODEX_MAC.md
+++ b/CURRICULUM_CODEX_MAC.md
@@ -278,6 +278,7 @@ brew install gh
 
 # ない場合はCodex CLIが適切な方法を案内してくれる
 gh auth login   # ブラウザでGitHub認証
+gh auth status  # 認証済みと表示されることを確認
 ```
 
 ## タスク P0-4: Python + 仮想環境のセットアップ
@@ -292,7 +293,7 @@ uvを使ってtaskrプロジェクトのPython環境をセットアップして�
 4. uv init --python 3.12
 5. uv venv
 6. uv add click
-7. uv add --dev pytest ruff
+7. uv add --dev pytest ruff pytest-cov
 8. uv run python --version で動作確認
 9. pyproject.tomlの内容を表示して確認
 
@@ -547,7 +548,7 @@ git checkout -b feature/phase1-design
 # 作業完了後
 git add AGENTS.md
 git commit -m "docs(phase1): add design decisions and taskr architecture plan"
-git push origin feature/phase1-design
+git push -u origin feature/phase1-design
 
 # Pull Requestを手動で作成
 gh pr create \
@@ -711,7 +712,7 @@ git add -u   # 手動でステージング
 
 ```bash
 # push と PR作成は手動
-git push origin feature/phase2-core-impl
+git push -u origin feature/phase2-core-impl
 gh pr create \
   --title "feat(phase2): implement core taskr CLI" \
   --body "add/list/done/deleteコマンドとJSONストレージを実装。pytestテスト付き。" \
@@ -898,7 +899,7 @@ git add taskr/.codexignore AGENTS.md
 ```
 
 ```bash
-git push origin feature/phase3-notify-commands
+git push -u origin feature/phase3-notify-commands
 gh pr create \
   --title "feat(phase3): add notify config and taskr-status custom command" \
   --body "config.tomlのnotify設定を追加。カスタムコマンド(/taskr-status)を自作。" \

--- a/CURRICULUM_CODEX_WINDOWS.md
+++ b/CURRICULUM_CODEX_WINDOWS.md
@@ -112,6 +112,13 @@
 
 ## Step 1: WSL2 + Ubuntu 22.04 のインストール
 
+> **PowerShell スクリプト実行ポリシーの設定（初回のみ）**
+> PowerShell を管理者として起動し、以下を実行してください:
+> ```powershell
+> Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+> ```
+> これを設定しないと、インストールスクリプトがブロックされます。
+
 **PowerShellで実行（管理者権限不要）:**
 
 ```powershell
@@ -170,6 +177,7 @@ sudo apt install git -y
 # ユーザー設定
 git config --global user.name "あなたの名前"
 git config --global user.email "あなたのメール"
+git config --global core.autocrlf false  # WSL2環境ではLFに統一
 ```
 
 ---
@@ -217,6 +225,7 @@ export OPENAI_API_KEY="sk-..."   # 取得したAPIキー
 # 永続化（~/.bashrc または ~/.zshrc に追記）
 echo 'export OPENAI_API_KEY="sk-..."' >> ~/.bashrc
 source ~/.bashrc
+echo $OPENAI_API_KEY  # 値が表示されればOK（先頭の sk- が見えればよい）
 ```
 
 ---
@@ -227,6 +236,7 @@ source ~/.bashrc
 # WSL2（Ubuntu）ターミナルで実行
 sudo apt install gh -y
 gh auth login   # ブラウザでGitHub認証
+gh auth status  # 認証済みと表示されることを確認
 ```
 
 ---
@@ -334,6 +344,7 @@ uv --version   # 確認
 # Ubuntu（WSL2）での gh CLI インストール
 sudo apt install gh -y
 gh auth login   # ブラウザでGitHub認証
+gh auth status  # 認証済みと表示されることを確認
 ```
 
 ## タスク P0-4: Python + 仮想環境のセットアップ
@@ -348,7 +359,7 @@ uvを使ってtaskrプロジェクトのPython環境をWSL2（Ubuntu）上でセ
 4. uv init --python 3.12
 5. uv venv
 6. uv add click
-7. uv add --dev pytest ruff
+7. uv add --dev pytest ruff pytest-cov
 8. uv run python --version で動作確認
 9. pyproject.tomlの内容を表示して確認
 
@@ -618,7 +629,7 @@ taskrプロジェクトに必要な依存関係が揃っているか評価して
 git checkout -b feature/phase1-design
 git add AGENTS.md
 git commit -m "docs(phase1): add design decisions and taskr architecture plan"
-git push origin feature/phase1-design
+git push -u origin feature/phase1-design
 gh pr create \
   --title "docs(phase1): add design decisions" \
   --body "Suggest Modeで確認した設計内容をAGENTS.mdに記録" \
@@ -791,7 +802,7 @@ git add -u
 ```
 
 ```bash
-git push origin feature/phase2-core-impl
+git push -u origin feature/phase2-core-impl
 gh pr create \
   --title "feat(phase2): implement core taskr CLI" \
   --body "add/list/done/deleteコマンドとJSONストレージを実装。pytestテスト付き。" \
@@ -848,6 +859,9 @@ notify設定2: notify-send が使える場合はデスクトップ通知も追�
 > macOSの `osascript` はWSL2では使えない。
 > WSL2ではターミナルへの `echo` 出力か `notify-send` を使う。
 > `notify-send` を使うにはWSL2の GUI統合（WSLg）が有効である必要がある。
+
+> **注意:** `notify-send` を使ったデスクトップ通知は WSLg（Windows 11 + WSL2）が必要です。
+> Windows 10 の場合は `echo` を使ったコンソール出力に変更してください。
 
 ## タスク P3-2: config.toml の高度な設定
 
@@ -972,7 +986,7 @@ git add taskr/.codexignore AGENTS.md
 ```
 
 ```bash
-git push origin feature/phase3-hooks-custom-cmd
+git push -u origin feature/phase3-hooks-custom-cmd
 gh pr create \
   --title "feat(phase3): add codexignore and update AGENTS.md" \
   --body "notify hook設定、カスタムコマンド(/taskr-status, /end-phase)を自作。" \
@@ -1026,6 +1040,8 @@ env = { GITHUB_PERSONAL_ACCESS_TOKEN = "$GITHUB_TOKEN" }
 
 事前に必要なこと:
 1. GitHub Personal Access Token を取得（Settings → Developer settings → Personal access tokens）
+   > **必要な PAT スコープ:** `repo`, `workflow`
+   > GitHub の Settings → Developer settings → Personal access tokens で作成してください。
 2. ~/.bashrc に export GITHUB_TOKEN="ghp_..." を追加
 3. source ~/.bashrc
 
@@ -1033,6 +1049,9 @@ env = { GITHUB_PERSONAL_ACCESS_TOKEN = "$GITHUB_TOKEN" }
 1. GitHub MCPでlearn_claudeリポジトリのIssue一覧を取得
 2. Phase 3で作成したIssueをMCP経由でクローズ
 ```
+
+設定後は `/quit` でセッションを終了し、新しいセッションを開始してください。
+その後 `/status` で GitHub MCP が読み込まれていることを確認してください。
 
 > **Codex CLIのMCP設定について:**
 > Claude Codeが `.mcp.json` を使うのに対し、


### PR DESCRIPTION
## 変更概要

OSをインストールしたばかりの状態から環境構築した場合に動かない設定漏れを、全4カリキュラムで修正。

## 🔴 Priority 1（必ず動かない）の修正

| 修正内容 | 対象 |
|---------|------|
| `commit-commands`, `feature-dev` プラグインを `enabledPlugins` に追加 | Claude MAC/WIN |
| `mkdir -p ~/.claude` と `source ~/.zshrc` 確認手順を追加 | Claude MAC/WIN |
| Phase 3 冒頭に `mkdir -p ~/.claude/hooks` を追加 | Claude MAC/WIN |
| `pytest-cov` を Phase 0 の `uv add --dev` に追加（Phase 7 の `--cov` 対応） | Codex MAC/WIN |
| 各フェーズの `git push` に `-u` フラグを追加 | Codex WIN |
| PowerShell ExecutionPolicy 設定手順を事前準備に追加 | Codex WIN |
| MCP 設定後のセッション再起動と PAT スコープ要件を追記 | Codex WIN |

## 🟡 Priority 2（高確率でつまずく）の修正

| 修正内容 | 対象 |
|---------|------|
| `gh auth login` 後に `gh auth status` 確認ステップを追加 | 全カリキュラム |
| `git config --global core.autocrlf false` を追加 | Codex WIN |
| `notify-send` の WSLg 要件（Windows 11 必須）を追記 | Codex WIN |

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)