### PR TITLE
fix: Phase 2 の git add -u を新規ファイル対応に修正

### DIFF
--- a/CURRICULUM_CLAUDE_MAC.md
+++ b/CURRICULUM_CLAUDE_MAC.md
@@ -658,7 +658,7 @@ gh CLIを使って以下のIssueをGitHubに作成してください:
 コミットはSkillに委譲し、push・PRはまだ手動：
 
 ```bash
-git add -u   # 手動でステージング
+git add taskr/ tests/ README.md   # 新規ファイルも含めてステージング
 ```
 
 ```text

--- a/CURRICULUM_CLAUDE_WINDOWS.md
+++ b/CURRICULUM_CLAUDE_WINDOWS.md
@@ -669,7 +669,7 @@ gh CLIを使って以下のIssueをGitHubに作成してください:
 ## Phase 2 コミット & プッシュ【/commit スキル + 手動push/PR】
 
 ```powershell
-git add -u
+git add taskr/ tests/ README.md   # 新規ファイルも含めてステージング
 ```
 
 ```text


### PR DESCRIPTION
## Summary
- Phase 2 コミットセクションの `git add -u` を `git add taskr/ tests/ README.md` に変更
- `git add -u` は追跡済みファイルのみが対象のため、新規作成ファイルがステージングされない問題を修正

Closes #24

## Test plan
- [ ] Phase 2 のコミット手順で新規ファイルがステージングされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)